### PR TITLE
Update league/csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed minimum PHP Version to 7.1
 
 ### Changed Dependencies
+- Updated league/csv to 9.2.1
 - Updated Laravel Illuminate packages to 5.8
 - Updated PHPUnit to 7.5
 - Updated Mockery to 1.2

--- a/app/sprinkles/core/composer.json
+++ b/app/sprinkles/core/composer.json
@@ -32,7 +32,7 @@
         "illuminate/database": "5.8.*",
         "illuminate/events": "5.8.*",
         "illuminate/filesystem": "5.8.*",
-        "league/csv": "^8.1",
+        "league/csv": "^9.2.1",
         "league/flysystem": "~1.0",
         "league/flysystem-aws-s3-v3": "~1.0",
         "league/flysystem-cached-adapter": "~1.0",


### PR DESCRIPTION
The only place this package is used is [here](https://github.com/userfrosting/UserFrosting/blob/master/app/sprinkles/core/src/Sprunje/Sprunje.php#L247).

`php bakery test` passed and manual testing of table csv export did not have any errors.

I believe this package can safely be updated without complications. 