### PR TITLE
Update PHPMailer to 6.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed minimum PHP Version to 7.1
 
 ### Changed Dependencies
+- Updated PHPMailer/PHPMailer to 6.0.7
 - Updated league/csv to 9.2.1
 - Updated Laravel Illuminate packages to 5.8
 - Updated Twig from 1.x to 2.x

--- a/app/sprinkles/core/composer.json
+++ b/app/sprinkles/core/composer.json
@@ -39,7 +39,7 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-sftp": "~1.0",
         "monolog/monolog": "^1",
-        "phpmailer/phpmailer": "5.2.10",
+        "phpmailer/phpmailer": "6.0.7",
         "slim/csrf": "^0.8",
         "slim/slim": "^3",
         "slim/twig-view": "^2.5",

--- a/app/sprinkles/core/composer.json
+++ b/app/sprinkles/core/composer.json
@@ -39,7 +39,7 @@
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-sftp": "~1.0",
         "monolog/monolog": "^1",
-        "phpmailer/phpmailer": "6.0.7",
+        "phpmailer/phpmailer": "^6.0.7",
         "slim/csrf": "^0.8",
         "slim/slim": "^3",
         "slim/twig-view": "^2.5",

--- a/app/sprinkles/core/src/Mail/Mailer.php
+++ b/app/sprinkles/core/src/Mail/Mailer.php
@@ -11,6 +11,8 @@
 namespace UserFrosting\Sprinkle\Core\Mail;
 
 use Monolog\Logger;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception as phpmailerException;
 
 /**
  * Mailer Class.
@@ -37,14 +39,14 @@ class Mailer
      * @param Logger  $logger A Monolog logger, used to dump debugging info for SMTP server transactions.
      * @param mixed[] $config An array of configuration parameters for phpMailer.
      *
-     * @throws \phpmailerException Wrong mailer config value given.
+     * @throws phpmailerException Wrong mailer config value given.
      */
     public function __construct($logger, $config = [])
     {
         $this->logger = $logger;
 
         // 'true' tells PHPMailer to use exceptions instead of error codes
-        $this->phpMailer = new \PHPMailer(true);
+        $this->phpMailer = new PHPMailer(true);
 
         // Configuration options
         switch ($config['mailer']) {
@@ -79,7 +81,7 @@ class Mailer
                 }
                 break;
             default:
-                throw new \phpmailerException("'mailer' must be one of 'smtp', 'mail', 'qmail', or 'sendmail'.");
+                throw new phpmailerException("'mailer' must be one of 'smtp', 'mail', 'qmail', or 'sendmail'.");
         }
 
         // Set any additional message-specific options
@@ -97,7 +99,7 @@ class Mailer
     /**
      * Get the underlying PHPMailer object.
      *
-     * @return \PHPMailer
+     * @return PHPMailer
      */
     public function getPhpMailer()
     {
@@ -113,7 +115,7 @@ class Mailer
      * @param MailMessage $message
      * @param bool        $clearRecipients Set to true to clear the list of recipients in the message after calling send().  This helps avoid accidentally sending a message multiple times.
      *
-     * @throws \phpmailerException The message could not be sent.
+     * @throws phpmailerException The message could not be sent.
      */
     public function send(MailMessage $message, $clearRecipients = true)
     {
@@ -163,7 +165,7 @@ class Mailer
      * @param MailMessage $message
      * @param bool        $clearRecipients Set to true to clear the list of recipients in the message after calling send().  This helps avoid accidentally sending a message multiple times.
      *
-     * @throws \phpmailerException The message could not be sent.
+     * @throws phpmailerException The message could not be sent.
      */
     public function sendDistinct(MailMessage $message, $clearRecipients = true)
     {


### PR DESCRIPTION
`php bakery test` and `php bakery test:mail` both passed with these changes. 

PHPMailer now uses namespace [`PHPMailer/PHPMailer`](https://github.com/PHPMailer/PHPMailer/blob/master/UPGRADING.md#namespace)

PHPMailer now uses its own namespaced [`Exception` class.](https://github.com/PHPMailer/PHPMailer/blob/master/UPGRADING.md#namespaced-exceptions)